### PR TITLE
Group all dependencies in dependabot config, add test-report job to c…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/check-data.yml
+++ b/.github/workflows/check-data.yml
@@ -14,6 +14,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  test-report:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run report tests
+        run: pnpm run --filter report test
+
   check-data:
     runs-on: ubuntu-latest
     permissions:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,40 +31,52 @@ importers:
 
   report:
     dependencies:
-      '@types/node':
-        specifier: ^25.6.0
-        version: 25.6.0
-      '@types/react':
-        specifier: ^18.3.28
-        version: 18.3.28
-      '@types/react-dom':
-        specifier: ^19.2.3
-        version: 19.2.3(@types/react@18.3.28)
       react:
         specifier: ^18.3.1
         version: 18.3.1
       react-dom:
-        specifier: ^19.2.5
-        version: 19.2.5(react@18.3.1)
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
       react-scripts:
         specifier: 5.0.1
-        version: 5.0.1(@babel/plugin-syntax-flow@7.28.6(@babel/core@7.29.0))(@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0))(@types/babel__core@7.20.5)(eslint@8.57.0)(react@18.3.1)(type-fest@0.21.3)(typescript@4.9.5)(yaml@2.8.1)
-      typescript:
-        specifier: ^4.9.5
-        version: 4.9.5
+        version: 5.0.1(@babel/plugin-syntax-flow@7.28.6(@babel/core@7.29.0))(@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0))(@types/babel__core@7.20.5)(eslint@8.57.1)(react@18.3.1)(type-fest@0.21.3)(typescript@4.9.5)
       web-vitals:
         specifier: ^2.1.4
         version: 2.1.4
-      zod:
-        specifier: ^4.3.6
-        version: 4.3.6
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20260412.1
         version: 4.20260412.1
+      '@testing-library/dom':
+        specifier: ^10.4.0
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/node':
+        specifier: ^16.18.126
+        version: 16.18.126
+      '@types/react':
+        specifier: ^18.3.28
+        version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18.3.7
+        version: 18.3.7(@types/react@18.3.28)
+      jest-canvas-mock:
+        specifier: ^2.5.2
+        version: 2.5.2
       tailwindcss:
-        specifier: ^4.2.2
-        version: 4.2.2
+        specifier: ^3.4.19
+        version: 3.4.19
+      typescript:
+        specifier: ^4.9.5
+        version: 4.9.5
       wrangler:
         specifier: 'catalog:'
         version: 4.81.1(@cloudflare/workers-types@4.20260412.1)
@@ -76,6 +88,9 @@ importers:
         version: 1.20260412.1
 
 packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -1143,12 +1158,12 @@ packages:
     resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  '@eslint/js@8.57.0':
-    resolution: {integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==}
+  '@eslint/js@8.57.1':
+    resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  '@humanwhocodes/config-array@0.11.14':
-    resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
+  '@humanwhocodes/config-array@0.13.0':
+    resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
     deprecated: Use @eslint/config-array instead
 
@@ -1559,9 +1574,41 @@ packages:
     resolution: {integrity: sha512-DOBOK255wfQxguUta2INKkzPj6AIS6iafZYiYmHn6W3pHlycSRRlvWKCfLDG10fXfLWqE3DJHgRUOyJYmARa7g==}
     engines: {node: '>=10'}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tootallnate/once@1.1.2':
     resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
     engines: {node: '>= 6'}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -1644,8 +1691,8 @@ packages:
   '@types/node-forge@1.3.14':
     resolution: {integrity: sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==}
 
-  '@types/node@25.6.0':
-    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+  '@types/node@16.18.126':
+    resolution: {integrity: sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==}
 
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
@@ -1665,10 +1712,10 @@ packages:
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
 
-  '@types/react-dom@19.2.3':
-    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
     peerDependencies:
-      '@types/react': ^19.2.0
+      '@types/react': ^18.0.0
 
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
@@ -1954,6 +2001,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -2470,6 +2520,9 @@ packages:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssdb@7.11.2:
     resolution: {integrity: sha512-lhQ32TFkc1X4eTefGfYPvgovRSzIMofHkigfH8nWtyRL4XJLsRhJFreRvEgKzept7x1rjBuy3J/MurXLaFxW/A==}
 
@@ -2477,6 +2530,9 @@ packages:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  cssfontparser@1.2.1:
+    resolution: {integrity: sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg==}
 
   cssnano-preset-default@5.2.14:
     resolution: {integrity: sha512-t0SFesj/ZV2OTylqQVOrFgEh5uanxbO6ZAdeCrNsUQ6fVuXwYTxJPNAGvGTxHbD68ldIJNec7PyYZDBrfDQ+6A==}
@@ -2601,6 +2657,10 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -2646,6 +2706,12 @@ packages:
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dom-converter@0.2.0:
     resolution: {integrity: sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==}
@@ -2922,8 +2988,8 @@ packages:
       eslint: ^7.0.0 || ^8.0.0
       webpack: ^5.0.0
 
-  eslint@8.57.0:
-    resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
+  eslint@8.57.1:
+    resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
@@ -3388,6 +3454,10 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
@@ -3608,6 +3678,9 @@ packages:
     resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  jest-canvas-mock@2.5.2:
+    resolution: {integrity: sha512-vgnpPupjOL6+L5oJXzxTxFrlGEIbHdZqFU+LFNdtLxZ3lRDCl17FlTMM7IatoRQkrcyOTMlDinjUguqmQ6bR2A==}
 
   jest-changed-files@27.5.1:
     resolution: {integrity: sha512-buBLMiByfWGCoMsLLzGUUSpAmIAGnbR2KJoMN10ziLhOLvP4e0SlypHnAel8iqQXTrcbmfEY9sSqae5sgUsTvw==}
@@ -3944,6 +4017,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.25.9:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
 
@@ -4015,6 +4092,10 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
   mini-css-extract-plugin@2.10.2:
     resolution: {integrity: sha512-AOSS0IdEB95ayVkxn5oGzNQwqAi2J0Jb/kKm43t7H73s8+f5873g0yuj0PNvK4dO75mu5DHg4nlgp4k6Kga8eg==}
     engines: {node: '>= 12.13.0'}
@@ -4042,6 +4123,9 @@ packages:
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
+
+  moo-color@1.0.3:
+    resolution: {integrity: sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==}
 
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
@@ -4834,10 +4918,10 @@ packages:
       typescript:
         optional: true
 
-  react-dom@19.2.5:
-    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
-      react: ^19.2.5
+      react: ^18.3.1
 
   react-error-overlay@6.1.0:
     resolution: {integrity: sha512-SN/U6Ytxf1QGkw/9ve5Y+NxBbZM6Ht95tuXNMKs8EJyFa/Vy/+Co3stop3KBHARfn/giv+Lj1uUnTfOJ3moFEQ==}
@@ -4892,6 +4976,10 @@ packages:
   recursive-readdir@2.2.3:
     resolution: {integrity: sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==}
     engines: {node: '>=6.0.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -5062,8 +5150,8 @@ packages:
     resolution: {integrity: sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==}
     engines: {node: '>=10'}
 
-  scheduler@0.27.0:
-    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   schema-utils@2.7.0:
     resolution: {integrity: sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==}
@@ -5325,6 +5413,10 @@ packages:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -5391,9 +5483,6 @@ packages:
     resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
     engines: {node: '>=14.0.0'}
     hasBin: true
-
-  tailwindcss@4.2.2:
-    resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
 
   tapable@1.1.3:
     resolution: {integrity: sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==}
@@ -5557,9 +5646,6 @@ packages:
 
   underscore@1.13.6:
     resolution: {integrity: sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==}
-
-  undici-types@7.19.2:
-    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
   undici@7.24.4:
     resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
@@ -5916,11 +6002,6 @@ packages:
     resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
     engines: {node: '>= 6'}
 
-  yaml@2.8.1:
-    resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
-
   yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
     engines: {node: '>=10'}
@@ -5939,10 +6020,9 @@ packages:
   youch@4.1.0-beta.10:
     resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
-
 snapshots:
+
+  '@adobe/css-tools@4.4.4': {}
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -5980,11 +6060,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/eslint-parser@7.28.6(@babel/core@7.29.0)(eslint@8.57.0)':
+  '@babel/eslint-parser@7.28.6(@babel/core@7.29.0)(eslint@8.57.1)':
     dependencies:
       '@babel/core': 7.29.0
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 8.57.0
+      eslint: 8.57.1
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
 
@@ -7055,9 +7135,9 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@8.57.0)':
+  '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1)':
     dependencies:
-      eslint: 8.57.0
+      eslint: 8.57.1
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -7076,9 +7156,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@8.57.0': {}
+  '@eslint/js@8.57.1': {}
 
-  '@humanwhocodes/config-array@0.11.14':
+  '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
       debug: 4.4.3
@@ -7199,7 +7279,7 @@ snapshots:
   '@jest/console@27.5.1':
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
       chalk: 4.1.2
       jest-message-util: 27.5.1
       jest-util: 27.5.1
@@ -7208,7 +7288,7 @@ snapshots:
   '@jest/console@28.1.3':
     dependencies:
       '@jest/types': 28.1.3
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
       chalk: 4.1.2
       jest-message-util: 28.1.3
       jest-util: 28.1.3
@@ -7221,7 +7301,7 @@ snapshots:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.8.1
@@ -7255,14 +7335,14 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
       jest-mock: 27.5.1
 
   '@jest/fake-timers@27.5.1':
     dependencies:
       '@jest/types': 27.5.1
       '@sinonjs/fake-timers': 8.1.0
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
       jest-message-util: 27.5.1
       jest-mock: 27.5.1
       jest-util: 27.5.1
@@ -7280,7 +7360,7 @@ snapshots:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit: 0.1.2
@@ -7360,7 +7440,7 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
       '@types/yargs': 16.0.11
       chalk: 4.1.2
 
@@ -7369,7 +7449,7 @@ snapshots:
       '@jest/schemas': 28.1.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -7573,7 +7653,43 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tootallnate/once@1.1.2': {}
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -7599,20 +7715,20 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
 
   '@types/bonjour@3.5.13':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
 
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
       '@types/express-serve-static-core': 5.1.1
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
 
   '@types/eslint-scope@3.7.7':
     dependencies:
@@ -7635,14 +7751,14 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.8':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
       '@types/qs': 6.15.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
 
   '@types/express-serve-static-core@5.1.1':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
       '@types/qs': 6.15.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -7656,7 +7772,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
 
   '@types/html-minifier-terser@6.1.0': {}
 
@@ -7664,7 +7780,7 @@ snapshots:
 
   '@types/http-proxy@1.17.17':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -7684,11 +7800,9 @@ snapshots:
 
   '@types/node-forge@1.3.14':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
 
-  '@types/node@25.6.0':
-    dependencies:
-      undici-types: 7.19.2
+  '@types/node@16.18.126': {}
 
   '@types/parse-json@4.0.2': {}
 
@@ -7702,7 +7816,7 @@ snapshots:
 
   '@types/range-parser@1.2.7': {}
 
-  '@types/react-dom@19.2.3(@types/react@18.3.28)':
+  '@types/react-dom@18.3.7(@types/react@18.3.28)':
     dependencies:
       '@types/react': 18.3.28
 
@@ -7713,7 +7827,7 @@ snapshots:
 
   '@types/resolve@1.17.1':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
 
   '@types/retry@0.12.0': {}
 
@@ -7722,11 +7836,11 @@ snapshots:
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
 
   '@types/serve-index@1.9.4':
     dependencies:
@@ -7735,12 +7849,12 @@ snapshots:
   '@types/serve-static@1.15.10':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
       '@types/send': 0.17.6
 
   '@types/sockjs@0.3.36':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
 
   '@types/stack-utils@2.0.3': {}
 
@@ -7748,7 +7862,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -7760,15 +7874,15 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5)':
+  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@4.9.5)
       '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.0)(typescript@4.9.5)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@4.9.5)
+      '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.1)(typescript@4.9.5)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@4.9.5)
       debug: 4.4.3
-      eslint: 8.57.0
+      eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare-lite: 1.4.0
@@ -7779,21 +7893,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/experimental-utils@5.62.0(eslint@8.57.0)(typescript@4.9.5)':
+  '@typescript-eslint/experimental-utils@5.62.0(eslint@8.57.1)(typescript@4.9.5)':
     dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@4.9.5)
-      eslint: 8.57.0
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@4.9.5)
+      eslint: 8.57.1
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5)':
+  '@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5)':
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
       debug: 4.4.3
-      eslint: 8.57.0
+      eslint: 8.57.1
     optionalDependencies:
       typescript: 4.9.5
     transitivePeerDependencies:
@@ -7804,12 +7918,12 @@ snapshots:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
 
-  '@typescript-eslint/type-utils@5.62.0(eslint@8.57.0)(typescript@4.9.5)':
+  '@typescript-eslint/type-utils@5.62.0(eslint@8.57.1)(typescript@4.9.5)':
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@4.9.5)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@4.9.5)
       debug: 4.4.3
-      eslint: 8.57.0
+      eslint: 8.57.1
       tsutils: 3.21.0(typescript@4.9.5)
     optionalDependencies:
       typescript: 4.9.5
@@ -7832,15 +7946,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@5.62.0(eslint@8.57.0)(typescript@4.9.5)':
+  '@typescript-eslint/utils@5.62.0(eslint@8.57.1)(typescript@4.9.5)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.7.1
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
-      eslint: 8.57.0
+      eslint: 8.57.1
       eslint-scope: 5.1.1
       semver: 7.7.4
     transitivePeerDependencies:
@@ -8036,6 +8150,10 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -8632,9 +8750,13 @@ snapshots:
 
   css-what@6.2.2: {}
 
+  css.escape@1.5.1: {}
+
   cssdb@7.11.2: {}
 
   cssesc@3.0.0: {}
+
+  cssfontparser@1.2.1: {}
 
   cssnano-preset-default@5.2.14(postcss@8.5.9):
     dependencies:
@@ -8766,6 +8888,8 @@ snapshots:
 
   depd@2.0.0: {}
 
+  dequal@2.0.3: {}
+
   destroy@1.2.0: {}
 
   detect-libc@2.1.2: {}
@@ -8802,6 +8926,10 @@ snapshots:
   doctrine@3.0.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dom-converter@0.2.0:
     dependencies:
@@ -9047,23 +9175,23 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-react-app@7.0.1(@babel/plugin-syntax-flow@7.28.6(@babel/core@7.29.0))(@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0))(eslint@8.57.0)(jest@27.5.1)(typescript@4.9.5):
+  eslint-config-react-app@7.0.1(@babel/plugin-syntax-flow@7.28.6(@babel/core@7.29.0))(@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0))(eslint@8.57.1)(jest@27.5.1)(typescript@4.9.5):
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/eslint-parser': 7.28.6(@babel/core@7.29.0)(eslint@8.57.0)
+      '@babel/eslint-parser': 7.28.6(@babel/core@7.29.0)(eslint@8.57.1)
       '@rushstack/eslint-patch': 1.16.1
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5)
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@4.9.5)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@4.9.5)
       babel-preset-react-app: 10.1.0
       confusing-browser-globals: 1.0.11
-      eslint: 8.57.0
-      eslint-plugin-flowtype: 8.0.3(@babel/plugin-syntax-flow@7.28.6(@babel/core@7.29.0))(@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)
-      eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(jest@27.5.1)(typescript@4.9.5)
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.0)
-      eslint-plugin-react: 7.37.5(eslint@8.57.0)
-      eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
-      eslint-plugin-testing-library: 5.11.1(eslint@8.57.0)(typescript@4.9.5)
+      eslint: 8.57.1
+      eslint-plugin-flowtype: 8.0.3(@babel/plugin-syntax-flow@7.28.6(@babel/core@7.29.0))(@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)
+      eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(jest@27.5.1)(typescript@4.9.5)
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
+      eslint-plugin-react: 7.37.5(eslint@8.57.1)
+      eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
+      eslint-plugin-testing-library: 5.11.1(eslint@8.57.1)(typescript@4.9.5)
     optionalDependencies:
       typescript: 4.9.5
     transitivePeerDependencies:
@@ -9082,25 +9210,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.10)(eslint@8.57.0):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint-import-resolver-node@0.3.10)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@4.9.5)
-      eslint: 8.57.0
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@4.9.5)
+      eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-flowtype@8.0.3(@babel/plugin-syntax-flow@7.28.6(@babel/core@7.29.0))(@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0))(eslint@8.57.0):
+  eslint-plugin-flowtype@8.0.3(@babel/plugin-syntax-flow@7.28.6(@babel/core@7.29.0))(@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0))(eslint@8.57.1):
     dependencies:
       '@babel/plugin-syntax-flow': 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
-      eslint: 8.57.0
+      eslint: 8.57.1
       lodash: 4.18.1
       string-natural-compare: 3.0.1
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -9109,9 +9237,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 8.57.0
+      eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.10)(eslint@8.57.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint-import-resolver-node@0.3.10)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -9123,24 +9251,24 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@4.9.5)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(jest@27.5.1)(typescript@4.9.5):
+  eslint-plugin-jest@25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(jest@27.5.1)(typescript@4.9.5):
     dependencies:
-      '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.57.0)(typescript@4.9.5)
-      eslint: 8.57.0
+      '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.57.1)(typescript@4.9.5)
+      eslint: 8.57.1
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5)
       jest: 27.5.1
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.0):
+  eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1):
     dependencies:
       aria-query: 5.3.2
       array-includes: 3.1.9
@@ -9150,7 +9278,7 @@ snapshots:
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 8.57.0
+      eslint: 8.57.1
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -9159,11 +9287,11 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-react-hooks@4.6.2(eslint@8.57.0):
+  eslint-plugin-react-hooks@4.6.2(eslint@8.57.1):
     dependencies:
-      eslint: 8.57.0
+      eslint: 8.57.1
 
-  eslint-plugin-react@7.37.5(eslint@8.57.0):
+  eslint-plugin-react@7.37.5(eslint@8.57.1):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
@@ -9171,7 +9299,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.3.2
-      eslint: 8.57.0
+      eslint: 8.57.1
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
@@ -9185,10 +9313,10 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-testing-library@5.11.1(eslint@8.57.0)(typescript@4.9.5):
+  eslint-plugin-testing-library@5.11.1(eslint@8.57.1)(typescript@4.9.5):
     dependencies:
-      '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@4.9.5)
-      eslint: 8.57.0
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@4.9.5)
+      eslint: 8.57.1
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -9207,23 +9335,23 @@ snapshots:
 
   eslint-visitor-keys@3.4.3: {}
 
-  eslint-webpack-plugin@3.2.0(eslint@8.57.0)(webpack@5.106.1):
+  eslint-webpack-plugin@3.2.0(eslint@8.57.1)(webpack@5.106.1):
     dependencies:
       '@types/eslint': 8.56.12
-      eslint: 8.57.0
+      eslint: 8.57.1
       jest-worker: 28.1.3
       micromatch: 4.0.8
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       webpack: 5.106.1
 
-  eslint@8.57.0:
+  eslint@8.57.1:
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
       '@eslint-community/regexpp': 4.12.2
       '@eslint/eslintrc': 2.1.4
-      '@eslint/js': 8.57.0
-      '@humanwhocodes/config-array': 0.11.14
+      '@eslint/js': 8.57.1
+      '@humanwhocodes/config-array': 0.13.0
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
       '@ungap/structured-clone': 1.3.0
@@ -9447,7 +9575,7 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
-  fork-ts-checker-webpack-plugin@6.5.3(eslint@8.57.0)(typescript@4.9.5)(webpack@5.106.1):
+  fork-ts-checker-webpack-plugin@6.5.3(eslint@8.57.1)(typescript@4.9.5)(webpack@5.106.1):
     dependencies:
       '@babel/code-frame': 7.29.0
       '@types/json-schema': 7.0.15
@@ -9465,7 +9593,7 @@ snapshots:
       typescript: 4.9.5
       webpack: 5.106.1
     optionalDependencies:
-      eslint: 8.57.0
+      eslint: 8.57.1
 
   form-data@3.0.4:
     dependencies:
@@ -9772,6 +9900,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  indent-string@4.0.0: {}
+
   inflight@1.0.6:
     dependencies:
       once: 1.4.0
@@ -9987,6 +10117,11 @@ snapshots:
       filelist: 1.0.6
       picocolors: 1.1.1
 
+  jest-canvas-mock@2.5.2:
+    dependencies:
+      cssfontparser: 1.2.1
+      moo-color: 1.0.3
+
   jest-changed-files@27.5.1:
     dependencies:
       '@jest/types': 27.5.1
@@ -9998,7 +10133,7 @@ snapshots:
       '@jest/environment': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -10094,7 +10229,7 @@ snapshots:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
       jest-mock: 27.5.1
       jest-util: 27.5.1
       jsdom: 16.7.0
@@ -10109,7 +10244,7 @@ snapshots:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
       jest-mock: 27.5.1
       jest-util: 27.5.1
 
@@ -10119,7 +10254,7 @@ snapshots:
     dependencies:
       '@jest/types': 27.5.1
       '@types/graceful-fs': 4.1.9
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -10138,7 +10273,7 @@ snapshots:
       '@jest/source-map': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
       chalk: 4.1.2
       co: 4.6.0
       expect: 27.5.1
@@ -10193,7 +10328,7 @@ snapshots:
   jest-mock@27.5.1:
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
 
   jest-pnp-resolver@1.2.3(jest-resolve@27.5.1):
     optionalDependencies:
@@ -10231,7 +10366,7 @@ snapshots:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
       chalk: 4.1.2
       emittery: 0.8.1
       graceful-fs: 4.2.11
@@ -10282,7 +10417,7 @@ snapshots:
 
   jest-serializer@27.5.1:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
       graceful-fs: 4.2.11
 
   jest-snapshot@27.5.1:
@@ -10315,7 +10450,7 @@ snapshots:
   jest-util@27.5.1:
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -10324,7 +10459,7 @@ snapshots:
   jest-util@28.1.3:
     dependencies:
       '@jest/types': 28.1.3
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -10354,7 +10489,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest-util: 27.5.1
@@ -10364,7 +10499,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.10.2
@@ -10373,19 +10508,19 @@ snapshots:
 
   jest-worker@26.6.2:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
       merge-stream: 2.0.0
       supports-color: 7.2.0
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@28.1.3:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 16.18.126
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -10570,6 +10705,8 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lz-string@1.5.0: {}
+
   magic-string@0.25.9:
     dependencies:
       sourcemap-codec: 1.4.8
@@ -10623,6 +10760,8 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
+  min-indent@1.0.1: {}
+
   mini-css-extract-plugin@2.10.2(webpack@5.106.1):
     dependencies:
       schema-utils: 4.3.3
@@ -10656,6 +10795,10 @@ snapshots:
   mkdirp@0.5.6:
     dependencies:
       minimist: 1.2.8
+
+  moo-color@1.0.3:
+    dependencies:
+      color-name: 1.1.4
 
   ms@2.0.0: {}
 
@@ -11051,13 +11194,12 @@ snapshots:
       postcss: 8.5.9
       postcss-value-parser: 4.2.0
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.9)(yaml@2.8.1):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.9):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.5.9
-      yaml: 2.8.1
 
   postcss-loader@6.2.1(postcss@8.5.9)(webpack@5.106.1):
     dependencies:
@@ -11423,7 +11565,7 @@ snapshots:
       regenerator-runtime: 0.13.11
       whatwg-fetch: 3.6.20
 
-  react-dev-utils@12.0.1(eslint@8.57.0)(typescript@4.9.5)(webpack@5.106.1):
+  react-dev-utils@12.0.1(eslint@8.57.1)(typescript@4.9.5)(webpack@5.106.1):
     dependencies:
       '@babel/code-frame': 7.29.0
       address: 1.2.2
@@ -11434,7 +11576,7 @@ snapshots:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.57.0)(typescript@4.9.5)(webpack@5.106.1)
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.57.1)(typescript@4.9.5)(webpack@5.106.1)
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -11457,10 +11599,11 @@ snapshots:
       - supports-color
       - vue-template-compiler
 
-  react-dom@19.2.5(react@18.3.1):
+  react-dom@18.3.1(react@18.3.1):
     dependencies:
+      loose-envify: 1.4.0
       react: 18.3.1
-      scheduler: 0.27.0
+      scheduler: 0.23.2
 
   react-error-overlay@6.1.0: {}
 
@@ -11472,7 +11615,7 @@ snapshots:
 
   react-refresh@0.11.0: {}
 
-  react-scripts@5.0.1(@babel/plugin-syntax-flow@7.28.6(@babel/core@7.29.0))(@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0))(@types/babel__core@7.20.5)(eslint@8.57.0)(react@18.3.1)(type-fest@0.21.3)(typescript@4.9.5)(yaml@2.8.1):
+  react-scripts@5.0.1(@babel/plugin-syntax-flow@7.28.6(@babel/core@7.29.0))(@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0))(@types/babel__core@7.20.5)(eslint@8.57.1)(react@18.3.1)(type-fest@0.21.3)(typescript@4.9.5):
     dependencies:
       '@babel/core': 7.29.0
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.11.0)(type-fest@0.21.3)(webpack-dev-server@4.15.2(webpack@5.106.1))(webpack@5.106.1)
@@ -11489,9 +11632,9 @@ snapshots:
       css-minimizer-webpack-plugin: 3.4.1(webpack@5.106.1)
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
-      eslint: 8.57.0
-      eslint-config-react-app: 7.0.1(@babel/plugin-syntax-flow@7.28.6(@babel/core@7.29.0))(@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0))(eslint@8.57.0)(jest@27.5.1)(typescript@4.9.5)
-      eslint-webpack-plugin: 3.2.0(eslint@8.57.0)(webpack@5.106.1)
+      eslint: 8.57.1
+      eslint-config-react-app: 7.0.1(@babel/plugin-syntax-flow@7.28.6(@babel/core@7.29.0))(@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0))(eslint@8.57.1)(jest@27.5.1)(typescript@4.9.5)
+      eslint-webpack-plugin: 3.2.0(eslint@8.57.1)(webpack@5.106.1)
       file-loader: 6.2.0(webpack@5.106.1)
       fs-extra: 10.1.0
       html-webpack-plugin: 5.6.6(webpack@5.106.1)
@@ -11508,7 +11651,7 @@ snapshots:
       prompts: 2.4.2
       react: 18.3.1
       react-app-polyfill: 3.0.0
-      react-dev-utils: 12.0.1(eslint@8.57.0)(typescript@4.9.5)(webpack@5.106.1)
+      react-dev-utils: 12.0.1(eslint@8.57.1)(typescript@4.9.5)(webpack@5.106.1)
       react-refresh: 0.11.0
       resolve: 1.22.12
       resolve-url-loader: 4.0.0
@@ -11516,7 +11659,7 @@ snapshots:
       semver: 7.7.4
       source-map-loader: 3.0.2(webpack@5.106.1)
       style-loader: 3.3.4(webpack@5.106.1)
-      tailwindcss: 3.4.19(yaml@2.8.1)
+      tailwindcss: 3.4.19
       terser-webpack-plugin: 5.4.0(webpack@5.106.1)
       webpack: 5.106.1
       webpack-dev-server: 4.15.2(webpack@5.106.1)
@@ -11596,6 +11739,11 @@ snapshots:
   recursive-readdir@2.2.3:
     dependencies:
       minimatch: 3.1.5
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -11757,7 +11905,9 @@ snapshots:
     dependencies:
       xmlchars: 2.2.0
 
-  scheduler@0.27.0: {}
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
 
   schema-utils@2.7.0:
     dependencies:
@@ -12121,6 +12271,10 @@ snapshots:
 
   strip-final-newline@2.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@3.1.1: {}
 
   style-loader@3.3.4(webpack@5.106.1):
@@ -12194,7 +12348,7 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
-  tailwindcss@3.4.19(yaml@2.8.1):
+  tailwindcss@3.4.19:
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -12213,7 +12367,7 @@ snapshots:
       postcss: 8.5.9
       postcss-import: 15.1.0(postcss@8.5.9)
       postcss-js: 4.1.0(postcss@8.5.9)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.9)(yaml@2.8.1)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.9)
       postcss-nested: 6.2.0(postcss@8.5.9)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.12
@@ -12221,8 +12375,6 @@ snapshots:
     transitivePeerDependencies:
       - tsx
       - yaml
-
-  tailwindcss@4.2.2: {}
 
   tapable@1.1.3: {}
 
@@ -12389,8 +12541,6 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   underscore@1.13.6: {}
-
-  undici-types@7.19.2: {}
 
   undici@7.24.4: {}
 
@@ -12857,9 +13007,6 @@ snapshots:
 
   yaml@1.10.3: {}
 
-  yaml@2.8.1:
-    optional: true
-
   yargs-parser@20.2.9: {}
 
   yargs@16.2.0:
@@ -12886,5 +13033,3 @@ snapshots:
       '@speed-highlight/core': 1.2.15
       cookie: 1.1.1
       youch-core: 0.3.3
-
-  zod@4.3.6: {}

--- a/report/package.json
+++ b/report/package.json
@@ -3,19 +3,16 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@types/node": "^25.6.0",
-    "@types/react": "^18.3.28",
-    "@types/react-dom": "^19.2.3",
     "react": "^18.3.1",
-    "react-dom": "^19.2.5",
+    "react-dom": "^18.3.1",
     "react-scripts": "5.0.1",
-    "typescript": "^4.9.5",
-    "web-vitals": "^2.1.4",
-    "zod": "^4.3.6"
+    "web-vitals": "^2.1.4"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "test": "react-scripts test --watchAll=false",
+    "test:watch": "react-scripts test",
     "eject": "react-scripts eject",
     "deploy": "pnpm run build && wrangler pages deploy ./build",
     "preview": "pnpm run build && wrangler pages dev ./build"
@@ -39,7 +36,16 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260412.1",
-    "tailwindcss": "^4.2.2",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/node": "^16.18.126",
+    "@types/react": "^18.3.28",
+    "@types/react-dom": "^18.3.7",
+    "jest-canvas-mock": "^2.5.2",
+    "tailwindcss": "^3.4.19",
+    "typescript": "^4.9.5",
     "wrangler": "catalog:"
   }
 }

--- a/report/src/App.test.tsx
+++ b/report/src/App.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import App from "./App";
+
+// Mock the JSON imports
+jest.mock("./data/table-data.json", () => [
+  ["totals", 100, "100/0/0", "90/5/5", "85/10/5", "80/15/5"],
+  ["fs", 10, "supported", "supported", "mismatch", "missing"],
+  ["path", 5, "supported", "supported", "supported", "supported"],
+]);
+
+jest.mock("./data/versionMap.json", () => ({
+  node24: "v24.0.0",
+  workerd: "2024-01-01",
+  bun: "1.0.0",
+  deno: "1.40.0",
+}));
+
+jest.mock("./data/timestamp.json", () => ({
+  timestamp: "2024-01-15T10:00:00Z",
+}));
+
+jest.mock("./data/historical-support.json", () => [
+  {
+    date: "2024-01",
+    workerdVersion: "workerd@1.0",
+    supportPercentage: 75,
+    totalApis: 100,
+    supportedApis: 75,
+    publishedAt: "2024-01-01",
+  },
+  {
+    date: "2024-02",
+    workerdVersion: "workerd@1.1",
+    supportPercentage: 80,
+    totalApis: 100,
+    supportedApis: 80,
+    publishedAt: "2024-02-01",
+  },
+]);
+
+describe("App", () => {
+  it("renders without crashing", () => {
+    render(<App />);
+  });
+
+  it("displays the timestamp", () => {
+    render(<App />);
+    expect(screen.getByText(/Generated:/)).toBeInTheDocument();
+    expect(screen.getByText(/1\/15\/2024/)).toBeInTheDocument();
+  });
+
+  it("displays the 'Compatibility Table' button", () => {
+    render(<App />);
+    expect(
+      screen.getByRole("button", { name: /Compatibility Table/ })
+    ).toBeInTheDocument();
+  });
+
+  it("displays the 'Trend Chart' button", () => {
+    render(<App />);
+    expect(
+      screen.getByRole("button", { name: /Trend Chart/ })
+    ).toBeInTheDocument();
+  });
+
+  it("switches to trend view when Trend Chart button is clicked", () => {
+    render(<App />);
+
+    const trendButton = screen.getByRole("button", { name: /Trend Chart/ });
+    fireEvent.click(trendButton);
+
+    expect(
+      screen.getByText(/Workerd Node.js API Support Over Time/)
+    ).toBeInTheDocument();
+  });
+
+  it("displays the Expand All button in table view", () => {
+    render(<App />);
+    expect(
+      screen.getByRole("button", { name: /Expand All/ })
+    ).toBeInTheDocument();
+  });
+
+  it("displays the Collapse All button in table view", () => {
+    render(<App />);
+    expect(
+      screen.getByRole("button", { name: /Collapse All/ })
+    ).toBeInTheDocument();
+  });
+
+  it("displays the download CSV link in table view", () => {
+    render(<App />);
+    expect(screen.getByText(/Download \(.csv\)/)).toBeInTheDocument();
+  });
+
+  it("displays table headers correctly", () => {
+    render(<App />);
+
+    expect(screen.getByText("API")).toBeInTheDocument();
+    // "baseline" appears in both the table header and notes section, so use a more specific query
+    expect(screen.getAllByText(/baseline/)[0]).toBeInTheDocument();
+    expect(screen.getByText("Node.js")).toBeInTheDocument();
+    expect(screen.getByText("Cloudflare Workers")).toBeInTheDocument();
+    expect(screen.getByText("Bun")).toBeInTheDocument();
+    expect(screen.getByText("Deno")).toBeInTheDocument();
+  });
+
+  it("displays the Legend component", () => {
+    render(<App />);
+
+    expect(screen.getByText("Matching")).toBeInTheDocument();
+    expect(screen.getByText("Missing")).toBeInTheDocument();
+    expect(screen.getByText("Mismatch")).toBeInTheDocument();
+  });
+
+  it("displays notes section", () => {
+    render(<App />);
+
+    expect(screen.getByText("Notes")).toBeInTheDocument();
+    expect(
+      screen.getByText(/All percentages in the table represent/)
+    ).toBeInTheDocument();
+  });
+
+  it("renders the totals row", () => {
+    render(<App />);
+
+    expect(screen.getByText("Totals")).toBeInTheDocument();
+  });
+
+  it("renders data rows from mocked data", () => {
+    render(<App />);
+
+    expect(screen.getByText("fs")).toBeInTheDocument();
+    expect(screen.getByText("path")).toBeInTheDocument();
+  });
+});

--- a/report/src/App.tsx
+++ b/report/src/App.tsx
@@ -8,7 +8,6 @@ import { mismatch, matching, missing } from "./constants";
 import { Legend } from "./Legend";
 import { TableCell, TableHeaderCell, TableRow } from "./Table";
 import { formatPct, getDocsLink, getPolyfillSearchLink, pct } from "./utils";
-import { z } from "zod";
 import { ignoredModules } from "./ignored-modules.js";
 import { TrendChart } from "./TrendChart";
 
@@ -35,15 +34,7 @@ const targetTitles = {
   deno: "Deno",
 };
 
-const rowSchema = z.tuple([
-  z.string(), // key
-  z.number(), // leaf count
-  z.number().or(z.string()), // basline
-  // targets
-  ...Object.keys(targetTitles).map(() => z.number().or(z.string())),
-]);
-
-type RowData = z.infer<typeof rowSchema>;
+type RowData = [string, number, string | number, ...(string | number)[]];
 
 const App = () => {
   const [expanded, setExpanded] = useState<string[]>([]);
@@ -118,7 +109,7 @@ const App = () => {
               {baselineSupport}
             </span>
           </TableCell>
-          {targets.map((target) => {
+          {targets.map((target, index) => {
             const [matching, mismatch, missing] = (target as string)
               .split("/")
               .map((i) => parseInt(i as string));
@@ -141,7 +132,7 @@ const App = () => {
             const tooltip = `Missing: ${missing}\nMismatch: ${mismatch}\nMatching: ${matching}`;
 
             return (
-              <TableCell color={bgColor}>
+              <TableCell key={index} color={bgColor}>
                 <div
                   title={tooltip}
                   className={`flex gap-3 justify-center items-center`}
@@ -233,7 +224,7 @@ const App = () => {
             <div className="text-xs">{baselineCount}</div>
           </div>
         </TableCell>
-        {targetTotals.map((targetTotal) => {
+        {targetTotals.map((targetTotal, index) => {
           const [matching, mismatch, missing] = (targetTotal as string)
             .split("/")
             .map((i) => parseInt(i as string, 10));
@@ -247,7 +238,7 @@ const App = () => {
           const tooltip = `Matching: ${matching}\nMissing: ${missing}\nMismatch: ${mismatch}`;
 
           return (
-            <TableCell>
+            <TableCell key={index}>
               <div title={tooltip}>
                 <span className="text-sm font-semibold">
                   {formatPct(presentPct)}

--- a/report/src/Legend.test.tsx
+++ b/report/src/Legend.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import { Legend } from "./Legend";
+
+describe("Legend", () => {
+  it("renders without crashing", () => {
+    render(<Legend />);
+  });
+
+  it("displays 'Matching' label with correct emoji", () => {
+    render(<Legend />);
+
+    expect(screen.getByText("Matching")).toBeInTheDocument();
+    expect(screen.getByText("✅")).toBeInTheDocument();
+  });
+
+  it("displays 'Missing' label with correct emoji", () => {
+    render(<Legend />);
+
+    expect(screen.getByText("Missing")).toBeInTheDocument();
+    expect(screen.getByText("❌")).toBeInTheDocument();
+  });
+
+  it("displays 'Mismatch' label with correct emoji", () => {
+    render(<Legend />);
+
+    expect(screen.getByText("Mismatch")).toBeInTheDocument();
+    // The mismatch emoji may have a variation selector, so use a function matcher
+    expect(
+      screen.getByText((content) => content.includes("🩹"))
+    ).toBeInTheDocument();
+  });
+
+  it("has correct container styling classes", () => {
+    render(<Legend />);
+
+    const list = screen.getByRole("list");
+    expect(list).toHaveClass(
+      "flex",
+      "items-center",
+      "gap-4",
+      "border",
+      "border-slate-300",
+      "rounded-md",
+      "px-4",
+      "py-2"
+    );
+  });
+
+  it("renders all three legend items", () => {
+    render(<Legend />);
+
+    const listItems = screen.getAllByRole("listitem");
+    expect(listItems).toHaveLength(3);
+  });
+
+  it("labels have medium font weight", () => {
+    render(<Legend />);
+
+    const matchingLabel = screen.getByText("Matching");
+    const missingLabel = screen.getByText("Missing");
+    const mismatchLabel = screen.getByText("Mismatch");
+
+    expect(matchingLabel).toHaveClass("font-medium");
+    expect(missingLabel).toHaveClass("font-medium");
+    expect(mismatchLabel).toHaveClass("font-medium");
+  });
+});

--- a/report/src/Table.test.tsx
+++ b/report/src/Table.test.tsx
@@ -1,0 +1,195 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { TableHeaderCell, TableCell, TableRow } from "./Table";
+
+describe("TableHeaderCell", () => {
+  it("renders children correctly", () => {
+    render(
+      <table>
+        <thead>
+          <tr>
+            <TableHeaderCell width="w-[100px]">Header Content</TableHeaderCell>
+          </tr>
+        </thead>
+      </table>
+    );
+
+    expect(screen.getByText("Header Content")).toBeInTheDocument();
+  });
+
+  it("applies width class correctly", () => {
+    render(
+      <table>
+        <thead>
+          <tr>
+            <TableHeaderCell width="min-w-[200px]">Header</TableHeaderCell>
+          </tr>
+        </thead>
+      </table>
+    );
+
+    const cell = screen.getByText("Header");
+    expect(cell).toHaveClass("min-w-[200px]");
+  });
+
+  it("has correct base classes", () => {
+    render(
+      <table>
+        <thead>
+          <tr>
+            <TableHeaderCell width="w-auto">Header</TableHeaderCell>
+          </tr>
+        </thead>
+      </table>
+    );
+
+    const cell = screen.getByText("Header");
+    expect(cell).toHaveClass("p-1", "border", "border-slate-200", "py-2");
+  });
+});
+
+describe("TableCell", () => {
+  it("renders children correctly", () => {
+    render(
+      <table>
+        <tbody>
+          <tr>
+            <TableCell>Cell Content</TableCell>
+          </tr>
+        </tbody>
+      </table>
+    );
+
+    expect(screen.getByText("Cell Content")).toBeInTheDocument();
+  });
+
+  it("applies default transparent background when no color is provided", () => {
+    render(
+      <table>
+        <tbody>
+          <tr>
+            <TableCell>Default Cell</TableCell>
+          </tr>
+        </tbody>
+      </table>
+    );
+
+    const cell = screen.getByText("Default Cell");
+    expect(cell).toHaveClass("p-1", "border", "border-slate-200", "py-2");
+  });
+
+  it("applies green background and border for green color", () => {
+    render(
+      <table>
+        <tbody>
+          <tr>
+            <TableCell color="green">Green Cell</TableCell>
+          </tr>
+        </tbody>
+      </table>
+    );
+
+    const cell = screen.getByText("Green Cell");
+    expect(cell).toHaveClass("bg-emerald-300", "border-emerald-200");
+  });
+
+  it("applies yellow background and border for yellow color", () => {
+    render(
+      <table>
+        <tbody>
+          <tr>
+            <TableCell color="yellow">Yellow Cell</TableCell>
+          </tr>
+        </tbody>
+      </table>
+    );
+
+    const cell = screen.getByText("Yellow Cell");
+    expect(cell).toHaveClass("bg-amber-300", "border-amber-200");
+  });
+
+  it("applies red background and border for red color", () => {
+    render(
+      <table>
+        <tbody>
+          <tr>
+            <TableCell color="red">Red Cell</TableCell>
+          </tr>
+        </tbody>
+      </table>
+    );
+
+    const cell = screen.getByText("Red Cell");
+    expect(cell).toHaveClass("bg-red-300", "border-red-200");
+  });
+});
+
+describe("TableRow", () => {
+  it("renders children correctly", () => {
+    render(
+      <table>
+        <tbody>
+          <TableRow>
+            <td>Row Content</td>
+          </TableRow>
+        </tbody>
+      </table>
+    );
+
+    expect(screen.getByText("Row Content")).toBeInTheDocument();
+  });
+
+  it("has even row background class", () => {
+    render(
+      <table>
+        <tbody>
+          <TableRow>
+            <td>Test</td>
+          </TableRow>
+        </tbody>
+      </table>
+    );
+
+    const row = screen.getByText("Test").closest("tr");
+    expect(row).toHaveClass("even:bg-slate-100");
+  });
+
+  it("calls onClick handler when clicked", () => {
+    const handleClick = jest.fn();
+
+    render(
+      <table>
+        <tbody>
+          <TableRow onClick={handleClick}>
+            <td>Clickable Row</td>
+          </TableRow>
+        </tbody>
+      </table>
+    );
+
+    const row = screen.getByText("Clickable Row").closest("tr");
+    if (row) {
+      fireEvent.click(row);
+    }
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not throw when onClick is not provided", () => {
+    render(
+      <table>
+        <tbody>
+          <TableRow>
+            <td>Non-clickable Row</td>
+          </TableRow>
+        </tbody>
+      </table>
+    );
+
+    const row = screen.getByText("Non-clickable Row").closest("tr");
+    expect(() => {
+      if (row) {
+        fireEvent.click(row);
+      }
+    }).not.toThrow();
+  });
+});

--- a/report/src/TrendChart.test.tsx
+++ b/report/src/TrendChart.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { TrendChart } from "./TrendChart";
+
+describe("TrendChart", () => {
+  const mockData = [
+    {
+      date: "2024-01",
+      workerdVersion: "workerd@1.0",
+      supportPercentage: 75,
+      totalApis: 100,
+      supportedApis: 75,
+      publishedAt: "2024-01-01",
+    },
+    {
+      date: "2024-02",
+      workerdVersion: "workerd@1.1",
+      supportPercentage: 80,
+      totalApis: 100,
+      supportedApis: 80,
+      publishedAt: "2024-02-01",
+    },
+    {
+      date: "2024-03",
+      workerdVersion: "workerd@1.2",
+      supportPercentage: 85,
+      totalApis: 100,
+      supportedApis: 85,
+      publishedAt: "2024-03-01",
+    },
+  ];
+
+  it("renders without crashing with data", () => {
+    render(<TrendChart data={mockData} />);
+
+    expect(
+      screen.getByText(/Workerd Node.js API Support Over Time/)
+    ).toBeInTheDocument();
+  });
+
+  it("displays the chart title and description", () => {
+    render(<TrendChart data={mockData} />);
+
+    expect(
+      screen.getByText(/Workerd Node.js API Support Over Time/)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Percentage of Node.js APIs supported by Cloudflare Workers runtime/
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("renders a canvas element", () => {
+    render(<TrendChart data={mockData} />);
+
+    const canvas = document.querySelector("canvas");
+    expect(canvas).toBeInTheDocument();
+  });
+
+  it("displays latest support percentage", () => {
+    render(<TrendChart data={mockData} />);
+
+    expect(screen.getByText(/Latest:/)).toBeInTheDocument();
+    expect(screen.getByText(/85% support/)).toBeInTheDocument();
+  });
+
+  it("displays improvement since first data point", () => {
+    render(<TrendChart data={mockData} />);
+
+    expect(screen.getByText(/Improvement:/)).toBeInTheDocument();
+    expect(screen.getByText(/\+10.0% since 2024-01/)).toBeInTheDocument();
+  });
+
+  it("shows message when no data is available", () => {
+    render(<TrendChart data={[]} />);
+
+    expect(
+      screen.getByText(/No historical data available/)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/node --run generate:historical/)
+    ).toBeInTheDocument();
+  });
+
+  it("canvas has correct dimensions", () => {
+    render(<TrendChart data={mockData} />);
+
+    const canvas = document.querySelector("canvas");
+    expect(canvas).toHaveAttribute("width", "800");
+    expect(canvas).toHaveAttribute("height", "400");
+  });
+
+  it("canvas has correct styling classes", () => {
+    render(<TrendChart data={mockData} />);
+
+    const canvas = document.querySelector("canvas");
+    expect(canvas).toHaveClass("border", "border-gray-200", "cursor-crosshair");
+  });
+});

--- a/report/src/setupTests.ts
+++ b/report/src/setupTests.ts
@@ -1,0 +1,8 @@
+// jest-dom adds custom jest matchers for asserting on DOM nodes.
+// allows you to do things like:
+// expect(element).toHaveTextContent(/react/i)
+// learn more: https://github.com/testing-library/jest-dom
+import "@testing-library/jest-dom";
+
+// Mock canvas for TrendChart tests
+import "jest-canvas-mock";

--- a/report/src/utils.test.ts
+++ b/report/src/utils.test.ts
@@ -1,0 +1,127 @@
+import { getPolyfillSearchLink, getDocsLink, pct, formatPct } from "./utils";
+
+describe("getPolyfillSearchLink", () => {
+  it("returns correct URL for node20 target", () => {
+    const result = getPolyfillSearchLink("node20", "fs");
+    expect(result).toContain("github.com/search");
+    expect(result).toContain("repo:nodejs/node");
+    expect(result).toContain("fs");
+  });
+
+  it("returns correct URL for node22 target", () => {
+    const result = getPolyfillSearchLink("node22", "path");
+    expect(result).toContain("repo:nodejs/node");
+    expect(result).toContain("path");
+  });
+
+  it("returns correct URL for node24 target", () => {
+    const result = getPolyfillSearchLink("node24", "http");
+    expect(result).toContain("repo:nodejs/node");
+    expect(result).toContain("http");
+  });
+
+  it("returns correct URL for bun target", () => {
+    const result = getPolyfillSearchLink("bun", "crypto");
+    expect(result).toContain("repo:oven-sh/bun");
+    expect(result).toContain("crypto");
+  });
+
+  it("returns correct URL for deno target", () => {
+    const result = getPolyfillSearchLink("deno", "url");
+    expect(result).toContain("repo:denoland/deno");
+    expect(result).toContain("url");
+  });
+
+  it("returns correct URL for workerd target", () => {
+    const result = getPolyfillSearchLink("workerd", "buffer");
+    expect(result).toContain("repo:cloudflare/workerd");
+    expect(result).toContain("buffer");
+  });
+
+  it("returns encoded URL for special characters", () => {
+    const result = getPolyfillSearchLink("workerd", "createReadStream");
+    expect(result).not.toContain(" ");
+  });
+
+  it("returns base URL for unknown target", () => {
+    const result = getPolyfillSearchLink("unknown", "fs");
+    expect(result).toContain("github.com/search");
+  });
+});
+
+describe("getDocsLink", () => {
+  it("returns correct URL for simple module", () => {
+    const result = getDocsLink("fs");
+    expect(result).toBe("https://nodejs.org/docs/latest/api/fs.html");
+  });
+
+  it("removes trailing sub-paths", () => {
+    const result = getDocsLink("fs/promises");
+    expect(result).toBe("https://nodejs.org/docs/latest/api/fs.html");
+  });
+
+  it("replaces trace_events with tracing", () => {
+    const result = getDocsLink("trace_events");
+    expect(result).toBe("https://nodejs.org/docs/latest/api/tracing.html");
+  });
+
+  it("replaces constants with all", () => {
+    const result = getDocsLink("constants");
+    expect(result).toBe("https://nodejs.org/docs/latest/api/all.html");
+  });
+
+  it("replaces sys with util", () => {
+    const result = getDocsLink("sys");
+    expect(result).toBe("https://nodejs.org/docs/latest/api/util.html");
+  });
+
+  it("removes asterisks from path", () => {
+    const result = getDocsLink("fs*");
+    expect(result).toBe("https://nodejs.org/docs/latest/api/fs.html");
+  });
+
+  it("handles nested paths with trailing segment", () => {
+    const result = getDocsLink("path/win32");
+    expect(result).toBe("https://nodejs.org/docs/latest/api/path.html");
+  });
+});
+
+describe("pct", () => {
+  it("calculates percentage correctly", () => {
+    expect(pct(50, 100)).toBe(50);
+  });
+
+  it("calculates zero correctly", () => {
+    expect(pct(0, 100)).toBe(0);
+  });
+
+  it("calculates full percentage correctly", () => {
+    expect(pct(100, 100)).toBe(100);
+  });
+
+  it("handles fractional results", () => {
+    expect(pct(1, 3)).toBeCloseTo(33.333, 3);
+  });
+});
+
+describe("formatPct", () => {
+  it("formats zero without decimal places", () => {
+    expect(formatPct(0)).toBe("0%");
+  });
+
+  it("formats 100 without decimal places", () => {
+    expect(formatPct(100)).toBe("100%");
+  });
+
+  it("formats values between 0 and 100 with 1 decimal place", () => {
+    expect(formatPct(50)).toBe("50.0%");
+  });
+
+  it("formats fractional values correctly", () => {
+    expect(formatPct(33.333)).toBe("33.3%");
+  });
+
+  it("rounds values correctly", () => {
+    expect(formatPct(66.666)).toBe("66.7%");
+  });
+});

--- a/report/tsconfig.json
+++ b/report/tsconfig.json
@@ -17,5 +17,6 @@
     "jsx": "react-jsx",
     "types": ["@cloudflare/workers-types/2023-07-01"]
   },
-  "include": ["src", "data"]
+  "include": ["src", "data"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
 }


### PR DESCRIPTION
…heck-data workflow, and downgrade report dependencies to stable versions

- Configure dependabot to group all dependency updates together
- Add test-report job to validate report package tests in CI
- Downgrade react-dom from 19.2.5 to 18.3.1 for compatibility
- Downgrade tailwindcss from 4.2.2 to 3.4.19
- Downgrade @types/node from 25.6.0 to 16.18.126
- Downgrade @types/react-dom from 19.2.3 to 18.3.7
- Move type dependencies to devDependencies in report package
- Add testing-library packages and jest