### PR TITLE
Update synthetic key name from "*default*" to "*self*" and fix suppor…

### DIFF
--- a/generate-historical-data.mjs
+++ b/generate-historical-data.mjs
@@ -209,11 +209,11 @@ async function calculateSupportPercentage() {
     const moduleInfo = target[moduleName];
 
     // Stub module can be identified as a module that has only one key - the default,
-    // which in turn has only one key, the synthetic "*default*" key
+    // which in turn has only one key, the synthetic "*self*" key
     return (
       moduleInfo &&
       Object.keys(moduleInfo).length === 1 &&
-      moduleInfo.default?.["*default*"] &&
+      moduleInfo.default?.["*self*"] &&
       Object.keys(moduleInfo.default).length === 1
     );
   };

--- a/generate-table-data.mjs
+++ b/generate-table-data.mjs
@@ -66,11 +66,11 @@ const isPartOfStubModule = (target, keyPath) => {
   const moduleInfo = target[moduleName];
 
   // Stub module can be identified as a module that has only one key - the default,
-  // which in turn has only one key, the synthetic "*default*" key
+  // which in turn has only one key, the synthetic "*self*" key
   return (
     moduleInfo &&
     Object.keys(moduleInfo).length === 1 &&
-    moduleInfo.default?.["*default*"] &&
+    moduleInfo.default?.["*self*"] &&
     Object.keys(moduleInfo.default).length === 1
   );
 };

--- a/report/src/App.tsx
+++ b/report/src/App.tsx
@@ -63,13 +63,12 @@ const App = () => {
     }
 
     const renderSupportValue = (value: string) => {
-      console.log(value);
       switch (value) {
         case "supported":
           return matching;
-        case "unsupported":
+        case "mismatch":
           return mismatch;
-        case "missing":
+        case "unsupported":
         default:
           return missing;
       }


### PR DESCRIPTION
…t value mapping

- Change synthetic key identifier from "*default*" to "*self*" in stub module detection logic
- Update support value mapping: "mismatch" replaces "unsupported", "unsupported" becomes default case
- Remove debug console.log statement